### PR TITLE
fire mw.hook('wikipage.content') after loading a diff

### DIFF
--- a/src/rtrc.js
+++ b/src/rtrc.js
@@ -1118,6 +1118,8 @@
 					)
 					.fadeIn();
 
+				mw.hook('wikipage.content').fire($frame);
+
 				if (opt.app.massPatrol) {
 					$frame.find('.patrollink a').click();
 				}


### PR DESCRIPTION
passing the current $frame as argument
this fixes #9
